### PR TITLE
Otóż wróciłem i tu.

### DIFF
--- a/content/blocks/ammo/rtobum.hjson
+++ b/content/blocks/ammo/rtobum.hjson
@@ -1,4 +1,4 @@
-type: GenericSmelter
+type: GenericCrafter
 name: Monter rakiet torowo-burzących
 description: Montuje rakiety dostosowane specjalnie dla NWR. 
 health: 700
@@ -38,3 +38,14 @@ research: {
 ambientSound: drill
 ambientSoundVolume: 2
 outputItem: rtobu/4
+drawer: {
+  type: DrawMulti
+  drawers: [
+    {
+      type: DrawDefault
+    }
+    {
+      type: DrawFlame
+    }
+  ]
+}

--- a/content/blocks/drills/hydrofar.hjson
+++ b/content/blocks/drills/hydrofar.hjson
@@ -39,15 +39,9 @@ research: {
 ambientSound: techloop
 ambientSoundVolume: 0.5
 outputItem: spore-pod/3
-//Świre tu był
 drawer: {
   type: DrawMulti
   drawers: [
-    {
-      type: DrawLiquidRegion
-      drawLiquid: water
-      //W celu zamalowania całego bloku wraz z animacją cieczy, należy użyć DrawLiquidTile minus taki, iż blok jednak tej cieczy do działania wymaga.
-    }
     {
       type: DrawDefault
     }

--- a/content/blocks/drills/hydrofar.hjson
+++ b/content/blocks/drills/hydrofar.hjson
@@ -44,9 +44,9 @@ drawer: {
   type: DrawMulti
   drawers: [
     {
-      type: DrawLiquidTile
+      type: DrawLiquidRegion
       drawLiquid: water
-      //W celu zamalowania wyznaczonego regionu przez teksture "-liquid" należy użyć DrawLiquidRegion, minus taki, iż ciecz nie jest animowana.
+      //W celu zamalowania całego bloku wraz z animacją cieczy, należy użyć DrawLiquidTile minus taki, iż blok jednak tej cieczy do działania wymaga.
     }
     {
       type: DrawDefault

--- a/content/blocks/drills/hydrofar.hjson
+++ b/content/blocks/drills/hydrofar.hjson
@@ -39,3 +39,21 @@ research: {
 ambientSound: techloop
 ambientSoundVolume: 0.5
 outputItem: spore-pod/3
+//Świre tu był
+drawer: {
+  type: DrawMulti
+  drawers: [
+    {
+      type: DrawLiquidTile
+      liquid: water
+      //W celu zamalowania wyznaczonego regionu przez teksture "-liquid" należy użyć DrawLiquidRegion, minus taki, iż ciecz nie jest animowana.
+    }
+    {
+      type: DrawDefault
+    }
+    {
+      type: DrawFlame
+      //To od ognia
+    }
+  ]
+}

--- a/content/blocks/drills/hydrofar.hjson
+++ b/content/blocks/drills/hydrofar.hjson
@@ -1,4 +1,4 @@
-type: GenericSmelter
+type: AttributeCrafter
 name: Hydrofarma zarodników
 description: Dzięki przekaźnikowi jest w stanie przewidzieć pogodę. Używa mikroczipów do zapewnienia optimum dla zarodników. Ekstremalnie efektowne. Zalecane zasilanie pompą termalną.
 health: 800
@@ -6,6 +6,7 @@ size: 3
 updateEffect: sapped
 craftTime: 10
 hasItems: 10
+attribute: spores
 hasLiquid: 20
 consumes: {
   power: 2

--- a/content/blocks/drills/hydrofar.hjson
+++ b/content/blocks/drills/hydrofar.hjson
@@ -45,7 +45,7 @@ drawer: {
   drawers: [
     {
       type: DrawLiquidTile
-      liquid: water
+      drawLiquid: water
       //W celu zamalowania wyznaczonego regionu przez teksture "-liquid" należy użyć DrawLiquidRegion, minus taki, iż ciecz nie jest animowana.
     }
     {

--- a/content/blocks/v1misc/radioteleskop.hjson
+++ b/content/blocks/v1misc/radioteleskop.hjson
@@ -49,3 +49,15 @@ research: {
 ambientSound: techloop
 ambientSoundVolume: 2
 outputItem: przekaznik/1
+drawer: {
+  type: DrawMulti
+  drawers: [
+    {
+      type: DrawDefault
+    }
+    {
+      type: DrawFlame
+      //Robi to ten łogień nad blokiem
+    }
+  ]
+}

--- a/content/blocks/v1misc/radioteleskop.hjson
+++ b/content/blocks/v1misc/radioteleskop.hjson
@@ -1,4 +1,4 @@
-type: GenericSmelter
+type: GenericCrafter
 name: Radioteleskop
 description: Odbiera sygnały z kwatery głównej, potrafi wytworzyć uniwersalną technologię dalekiego przesyłu.
 health: 1500

--- a/content/blocks/v1misc/radioteleskop.hjson
+++ b/content/blocks/v1misc/radioteleskop.hjson
@@ -3,7 +3,7 @@ name: Radioteleskop
 description: Odbiera sygnały z kwatery głównej, potrafi wytworzyć uniwersalną technologię dalekiego przesyłu.
 health: 1500
 size: 4
-updateEffect: lancerLaserShoot
+updateEffect: lancerLaserCharge
 craftTime: 600
 hasItems: true
 itemCapacity: 20

--- a/content/blocks/v1misc/radioteleskop.hjson
+++ b/content/blocks/v1misc/radioteleskop.hjson
@@ -3,7 +3,7 @@ name: Radioteleskop
 description: Odbiera sygnały z kwatery głównej, potrafi wytworzyć uniwersalną technologię dalekiego przesyłu.
 health: 1500
 size: 4
-updateEffect: purify
+updateEffect: lancerLaserShoot
 craftTime: 600
 hasItems: true
 itemCapacity: 20

--- a/content/blocks/v2base/promienioskladacz.hjson
+++ b/content/blocks/v2base/promienioskladacz.hjson
@@ -41,3 +41,16 @@ research: {
 ambientSound: techloop
 ambientSoundVolume: 1
 outputItem: uran/3
+//Tutaj zaczyna się ingerencja sił dzbanowych
+drawer: {
+  type: DrawMulti
+  drawers: [
+    {
+      type: DrawDefault
+    }
+    {
+      type: DrawFlame
+      //Tak jak miał GenericSmelter
+    }
+  ]
+}

--- a/content/blocks/v2base/promienioskladacz.hjson
+++ b/content/blocks/v2base/promienioskladacz.hjson
@@ -1,4 +1,4 @@
-type: GenericSmelter
+type: GenericCrafter
 name: Promienioskładacz
 description: Za pomocą promieniowania z wzbogaconego toru wytwarza uran, jedyna możliwość jego pozyskania na Serpulo.
 health: 2000


### PR DESCRIPTION
Z tego właśnie utkane były błędy.

- `GenericSmelter` na `GenericCrafter` i dla hydro farmy na `AttributeCrafter`.

- Przywrócenie do działania (chyba) poprawnego trzech bloków.

- Dodanie w `draw`, `MultiDraw`, a w nim `DrawFlame` w celu uzyskania efektu przepalania.

- Zastępczy efekt dla obiektu o nazwie `radioteleskop`.

Inwestygacja i całe przedsięwzięcie na [`#polski`](https://discord.com/channels/391020510269669376/464567579747287040/1056912401787797506l)

```hjson
drawer: {
  type: DrawMulti
  drawers: [
    {
      type: DrawDefault
    }
    {
      type: DrawFlame
      //To od ognia
    }
  ]
}
```

`updateEffect: lancerLaserCharge`

`type: AttributeCrafter`
`attribute: spores`