### PR TITLE
Czas na niewielką, lecz rewolucyjną reformę

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Z.P.G.M._Mod
+# zpgm-Mod
 My mod;
 english translation is going to be avaible after 2.4 version;
 feel free to contribute sprites, see info.txt;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zpgm-Mod
+# Z.P.G.M._Mod
 My mod;
 english translation is going to be avaible after 2.4 version;
 feel free to contribute sprites, see info.txt;

--- a/content/blocks/multi/butelkownia.hjson
+++ b/content/blocks/multi/butelkownia.hjson
@@ -190,89 +190,89 @@ ambientSound: conveyor
 recipes: [
     {
         input: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: water/3
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelkaw/12
+            items: zpgm-mod-butelkaw/12
         }
         craftTime: 60
     }
     {
         input: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: cryofluid/3
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelkal/12
+            items: zpgm-mod-butelkal/12
         }
         craftTime: 60
     }
     {
         input: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: oil/3
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelkar/12
+            items: zpgm-mod-butelkar/12
         }
         craftTime: 60
     }
     {
         input: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: slag/3
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelkaz/12
+            items: zpgm-mod-butelkaz/12
         }
         craftTime: 60
     }
     # Unload
     {
         input: {
-            items: z.p.g.m._mod-butelkaw/12
+            items: zpgm-mod-butelkaw/12
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: water/3
         }
         craftTime: 60
     }
     {
         input: {
-            items: z.p.g.m._mod-butelkal/12
+            items: zpgm-mod-butelkal/12
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: cryofluid/3
         }
         craftTime: 60
     }
     {
         input: {
-            items: z.p.g.m._mod-butelkar/12
+            items: zpgm-mod-butelkar/12
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: oil/3
         }
         craftTime: 60
     }
     {
         input: {
-            items: z.p.g.m._mod-butelkaz/12
+            items: zpgm-mod-butelkaz/12
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
             fluids: slag/3
         }
         craftTime: 60

--- a/content/blocks/multi/huta.hjson
+++ b/content/blocks/multi/huta.hjson
@@ -128,7 +128,7 @@ recipes: [
             power: 1.2
         }
         output: {
-            items: z.p.g.m._mod-butelka/12
+            items: zpgm-mod-butelka/12
         }
         craftTime: 60
     }

--- a/content/blocks/multi/koele.hjson
+++ b/content/blocks/multi/koele.hjson
@@ -37,7 +37,7 @@ recipes: [
             power: 3.1
         }
         output: {
-            items: z.p.g.m._mod-baterian/2
+            items: zpgm-mod-baterian/2
         }
         craftTime: 690
     }
@@ -46,13 +46,13 @@ recipes: [
             items: [
                 copper/3
                 silicon/10
-                z.p.g.m._mod-nanoczesci/2
+                zpgm-mod-nanoczesci/2
             ]
             fluids: cryofluid/0.4
             power: 7
         }
         output: {
-            items: z.p.g.m._mod-mikroczip/1
+            items: zpgm-mod-mikroczip/1
         }
         craftTime: 120
     }
@@ -62,14 +62,14 @@ recipes: [
                 copper/5
                 titanium/12
                 silicon/15
-                z.p.g.m._mod-baterian/4
-                z.p.g.m._mod-nanoczesci/6
-                z.p.g.m._mod-mikroczip/2
+                zpgm-mod-baterian/4
+                zpgm-mod-nanoczesci/6
+                zpgm-mod-mikroczip/2
             ]
             power: 15
         }
         output: {
-            items: z.p.g.m._mod-przekaznik/1
+            items: zpgm-mod-przekaznik/1
         }
         craftTime: 420
     }

--- a/content/blocks/multi/ladowarka.hjson
+++ b/content/blocks/multi/ladowarka.hjson
@@ -24,31 +24,31 @@ ambientSound: drill
 recipes: [
     {
         input: {
-            items: z.p.g.m._mod-bateria/3
+            items: zpgm-mod-bateria/3
             power: 5
         }
         output: {
-            items: z.p.g.m._mod-baterian/3
+            items: zpgm-mod-baterian/3
         }
         craftTime: 600
     }
     {
         input: {
-            items: z.p.g.m._mod-baterian/3
+            items: zpgm-mod-baterian/3
         }
         output: {
-            items: z.p.g.m._mod-bateria/3
+            items: zpgm-mod-bateria/3
             power: 5
         }
         craftTime: 600
     }
     {
         input: {
-            items: z.p.g.m._mod-baterian/3
+            items: zpgm-mod-baterian/3
             fluids: water/1
         }
         output: {
-            items: z.p.g.m._mod-bateria/3
+            items: zpgm-mod-bateria/3
             power: 10
         }
         craftTime: 300

--- a/content/blocks/multi/piecyk.hjson
+++ b/content/blocks/multi/piecyk.hjson
@@ -31,7 +31,7 @@ recipes: [
             power: 2
         }
         output: {
-            items: z.p.g.m._mod-miedzgraf/2
+            items: zpgm-mod-miedzgraf/2
         }
         craftTime: 150
     }
@@ -46,7 +46,7 @@ recipes: [
             power: 5
         }
         output: {
-            items: z.p.g.m._mod-braz/1
+            items: zpgm-mod-braz/1
         }
         craftTime: 90
     }

--- a/content/blocks/multi/skladacz.hjson
+++ b/content/blocks/multi/skladacz.hjson
@@ -28,28 +28,28 @@ recipes: [
             items: [
                 copper/2
                 titanium/9
-                z.p.g.m._mod-butelkar/2
-                z.p.g.m._mod-baterian/1
+                zpgm-mod-butelkar/2
+                zpgm-mod-baterian/1
             ]
             power: 7
         }
         output: {
-            items: z.p.g.m._mod-nanoczesci/1
+            items: zpgm-mod-nanoczesci/1
         }
         craftTime: 300
     }
     {
         input: {
             items: [
-            z.p.g.m._mod-butelkar/3
-            z.p.g.m._mod-butelkaw/4
-            z.p.g.m._mod-butelkaz/2
-            z.p.g.m._mod-siarka/2
+            zpgm-mod-butelkar/3
+            zpgm-mod-butelkaw/4
+            zpgm-mod-butelkaz/2
+            zpgm-mod-siarka/2
             ]
             power: 4
         }
         output: {
-            items: z.p.g.m._mod-chemia/1
+            items: zpgm-mod-chemia/1
         }
         craftTime: 300
     }

--- a/content/items/braz.hjson
+++ b/content/items/braz.hjson
@@ -1,6 +1,6 @@
 name: Brąz szklany
 description: Bardziej złożony i trudniejszy w wytworzeniu materiał budowlany, używany w większych strukturach.
-color: 000000
+color: a4b19d
 research: {
   parent: miedzgraf
 }

--- a/content/items/miedzgraf.hjson
+++ b/content/items/miedzgraf.hjson
@@ -1,6 +1,6 @@
 name: Miedziografek
 description: Podstawowy, choć nieco mocniejszy materiał budowlany
-color: 000000
+color: eac2a9
 research: {
   parent: piecyk
 }

--- a/info.txt
+++ b/info.txt
@@ -2,5 +2,5 @@ mod zalecany tylko do kampanii, szczególnie pod koniec
 obecnie trwają prace nad dostosowaniem bloków pod multibloki i v7
 poszukiwana osoba do spritingu
 sprites to do: wytwarzaczb.hjson, koele.hjson
-code to do: kolory miedziografku i brązu szklanego, multiblok: monter amunicji, kompleks chemiczny
+code to do: multiblok: monter amunicji, kompleks chemiczny
 do następnego release cała zawartość z v1 powinna być oteksturowana podstawowo, a także zbalansowana i przystosowana do multicrafterow

--- a/mod.hjson
+++ b/mod.hjson
@@ -1,7 +1,8 @@
 name: "zpgm-mod"
-displayName: "zpgm-Mod"
+displayName: "Z.P.G.M. Mod"
 description: "Z.P.G.M. Mod dla dużej rozpierduchy oraz zabawy. Wspierający: Świrek, Not_Bot, Kamil, Zielony Trójkąt. Gigantyczne podziękowania dla Stalkera za zaanagżowanie w pracę z teksturami, oraz dla Dream Lorda (Hatrune Cubic), za nieocenioną pomoc z kodem (bez ciebie nie powstałoby nawet 1.0). [red]Discord: https://discord.gg/E3T9JxDuTP Mod currently unavaible in English. Ask about me in #polski in official mindustry discord if you want to contact."
 author: "r_omnom7"
+# Niby mamy teraz 145.1, ale nie weszło nic nic niezbędnęgo ostatnio, chyba.
 minGameVersion: "136"
 version: "2.1.3.5"
 dependencies:["multi-crafter"]

--- a/mod.hjson
+++ b/mod.hjson
@@ -1,6 +1,6 @@
-name: "Z.P.G.M._Mod"
+name: "zpgm-mod"
 displayName: "Z.P.G.M._Mod"
-description: "Z.P.G.M. Mod dla dużej rozpierduchy oraz zabawy. Wspierający: Świrek3331, Not_Bot, Kamil, Zielony Trójkąt. Gigantyczne podziękowania dla Stalkera za zaanagżowanie w pracę z teksturami, oraz dla Dream Lorda, za nieocenioną pomoc z kodem (bez ciebie nie powstałoby nawet 1.0). [red]Discord: https://discord.gg/E3T9JxDuTP Mod currently unavaible in English. Ask about me in #polski in official mindustry discord if you want to contact."
+description: "Z.P.G.M. Mod dla dużej rozpierduchy oraz zabawy. Wspierający: Świrek, Not_Bot, Kamil, Zielony Trójkąt. Gigantyczne podziękowania dla Stalkera za zaanagżowanie w pracę z teksturami, oraz dla Dream Lorda (Hatrune Cubic), za nieocenioną pomoc z kodem (bez ciebie nie powstałoby nawet 1.0). [red]Discord: https://discord.gg/E3T9JxDuTP Mod currently unavaible in English. Ask about me in #polski in official mindustry discord if you want to contact."
 author: "r_omnom7"
 minGameVersion: "136"
 version: "2.1.3.5"

--- a/mod.hjson
+++ b/mod.hjson
@@ -1,5 +1,5 @@
 name: "zpgm-mod"
-displayName: "Z.P.G.M._Mod"
+displayName: "zpgm-Mod"
 description: "Z.P.G.M. Mod dla dużej rozpierduchy oraz zabawy. Wspierający: Świrek, Not_Bot, Kamil, Zielony Trójkąt. Gigantyczne podziękowania dla Stalkera za zaanagżowanie w pracę z teksturami, oraz dla Dream Lorda (Hatrune Cubic), za nieocenioną pomoc z kodem (bez ciebie nie powstałoby nawet 1.0). [red]Discord: https://discord.gg/E3T9JxDuTP Mod currently unavaible in English. Ask about me in #polski in official mindustry discord if you want to contact."
 author: "r_omnom7"
 minGameVersion: "136"


### PR DESCRIPTION
Zmiana nazwy moda (nie tej wyświetlanej).

Praktycznie robi osobnego moda.
Wszystko, co kiedyś zostało zrobione, przepada.
Zato w końcu pozwala się do tego moda odnosić w bundle'ach i w innych modyfikacjach.